### PR TITLE
fix: fix videoAlpha being in percentage in older files, so loosen val…

### DIFF
--- a/lib/sb2_definitions.json
+++ b/lib/sb2_definitions.json
@@ -174,7 +174,7 @@
                 "videoAlpha": {
                     "type": "number",
                     "minimum": 0,
-                    "maximum": 1
+                    "maximum": 100
                 },
                 "children": {
                     "type": "array",


### PR DESCRIPTION
The purpose of this PR is to loosen the validation schema for the sb2 file types, the videoAlpha field is in percentage in older files so they fail being validated.